### PR TITLE
Improve documentation and add packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # Wiverno
 **Wiverno** — a lightweight WSGI framework for building fast and flexible Python web applications.
+
+## Installation
+
+Clone the repository and install the package using `pip`:
+
+```bash
+pip install .
+```
+
+## Minimal example
+
+```python
+from wiverno.main import Wiverno
+from wiverno.core.server import RunServer
+
+def index(request):
+    return "200 OK", "Hello, World!"
+
+app = Wiverno(routes_list=[("/", index)])
+RunServer(app).start()
+```
+
+## Running
+
+Save the example above to `app.py` and start the server:
+
+```bash
+python app.py
+```
+
+The application will be available at `http://localhost:8000/`.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+from pathlib import Path
+
+# Read version from package
+version = "0.0.0"
+
+with open(Path(__file__).resolve().parent / 'wiverno' / '__init__.py') as f:
+    for line in f:
+        if line.startswith('__version__'):
+            version = line.split('=')[1].strip().strip('"')
+            break
+
+setup(
+    name='wiverno',
+    version=version,
+    packages=find_packages(),
+    install_requires=[
+        'Jinja2==3.1.6',
+        'MarkupSafe==3.0.2'
+    ],
+    python_requires='>=3.8',
+    description='A lightweight WSGI framework',
+)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,0 +1,15 @@
+import io
+from wiverno.core.requests import Request
+
+def test_get_request_parsing():
+    environ = {
+        'REQUEST_METHOD': 'GET',
+        'PATH_INFO': '/hello/',
+        'QUERY_STRING': 'name=Wiverno',
+        'wsgi.input': io.BytesIO(b''),
+    }
+    req = Request(environ)
+    assert req.method == 'GET'
+    assert req.path == '/hello/'
+    assert req.query_params == {'name': 'Wiverno'}
+

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from wiverno.core.server import RunServer
+
+
+def dummy_app(environ, start_response):
+    start_response('200 OK', [('Content-Type', 'text/plain')])
+    return [b'OK']
+
+
+def test_runserver_start():
+    server = RunServer(dummy_app, host='127.0.0.1', port=9000)
+    with mock.patch('wiverno.core.server.make_server') as ms:
+        httpd = mock.MagicMock()
+        ms.return_value.__enter__.return_value = httpd
+        server.start()
+        ms.assert_called_with('127.0.0.1', 9000, dummy_app)
+        httpd.serve_forever.assert_called_once()
+

--- a/wiverno/__init__.py
+++ b/wiverno/__init__.py
@@ -1,0 +1,3 @@
+"""Wiverno framework package."""
+
+__version__ = "0.1.0"

--- a/wiverno/main.py
+++ b/wiverno/main.py
@@ -1,5 +1,6 @@
 import traceback
 import logging
+from pathlib import Path
 
 from typing import Callable, Dict, List, Tuple
 from wiverno.core.requests import Request
@@ -8,16 +9,20 @@ from wiverno.templating.templator import Templator
 logger = logging.getLogger(__name__)
 
 
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_TEMPLATE_PATH = BASE_DIR / "static" / "templates"
+
+
 class PageNotFound404:
-    
+
     def __call__(self, request):
-        templator = Templator(folder="wiverno\\static\\templates")
+        templator = Templator(folder=str(DEFAULT_TEMPLATE_PATH))
         return "404 WHAT", templator.render('error_404.html')
 
 class MethodNotAllowed405:
-    
+
     def __call__(self, request):
-        templator = Templator(folder="wiverno/static/templates")
+        templator = Templator(folder=str(DEFAULT_TEMPLATE_PATH))
         return "405 METHOD NOT ALLOWED", templator.render(
             "error_405.html", content={"method": request.method}
         )
@@ -33,7 +38,7 @@ class Wiverno:
         routes_list: List[Tuple[str, Callable[[Request], Tuple[str, str]]]],
         page_404: Callable[[Request], Tuple[str, str]] = PageNotFound404(),
         debug_mode: bool = True,
-        system_template_path: str = "wiverno\\static\\templates",
+        system_template_path: str = str(DEFAULT_TEMPLATE_PATH),
         page_500: Callable[[Request], Tuple[str, str]] = None
     ):
         """

--- a/wiverno/templating/templator.py
+++ b/wiverno/templating/templator.py
@@ -1,14 +1,15 @@
 import os
+from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 
 class Templator:
     def __init__(self, folder: str = "templates"):
-        
+
         self.env = Environment()
-        # Define the base directory of the project
-        self.base_dir = os.getcwd()
-        # Set the loader to the templates folder within the my_app directory
-        self.env.loader = FileSystemLoader(os.path.join(self.base_dir, folder))
+        # Base directory of the framework package
+        self.base_dir = Path(__file__).resolve().parent
+        # Load templates from the provided folder relative to the package
+        self.env.loader = FileSystemLoader(self.base_dir / folder)
         
     def render(self, template_name: str, content: dict = {}, **kwargs):
         """
@@ -16,8 +17,7 @@ class Templator:
 
         :param template_name: Name of the template file to render.
         :param content: Context data to pass to the template.
-        :param folder: Folder where the template is located.
-        :param kwargs: Context variables to pass to the template.
+        :param kwargs: Additional context variables.
         :return: Rendered HTML as a string.
         """
         # Load the template 


### PR DESCRIPTION
## Summary
- expand README with install instructions and sample usage
- fix template paths for OS independence
- clarify templator docstring and base path
- expose framework version and add setup.py
- provide basic tests for request parsing and server startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f55f81108330aa0c7045a428c1d2